### PR TITLE
Feexes

### DIFF
--- a/Armory/Mods/Armory/ScriptExtender/Lua/Client/Vanity/CharacterPanel/DyePicker.lua
+++ b/Armory/Mods/Armory/ScriptExtender/Lua/Client/Vanity/CharacterPanel/DyePicker.lua
@@ -288,6 +288,7 @@ function DyePicker:DisplayResult(dyeTemplate, displayGroup)
 	end
 
 	local favoriteButton = Styler:ImageButton(displayGroup:AddImageButton("Favorite" .. dyeTemplate.Id, isFavorited and "star_fileld" or "star_empty", { 26, 26 }))
+	favoriteButton.NoItemNav = true
 
 	local dyeImageButton = Styler:ImageButton(displayGroup:AddImageButton(dyeTemplate.Id, dyeTemplate.Icon, { self.settings.imageSize, self.settings.imageSize }))
 	dyeImageButton.UserData = materialPreset.Guid

--- a/Armory/Mods/Armory/ScriptExtender/Lua/Client/Vanity/CharacterPanel/PickerBaseClass.lua
+++ b/Armory/Mods/Armory/ScriptExtender/Lua/Client/Vanity/CharacterPanel/PickerBaseClass.lua
@@ -86,7 +86,7 @@ function PickerBaseClass:InitializeSearchBank()
 
 			if (stat.ModifierList == "Weapon" or stat.ModifierList == "Armor") then
 				indexShard = itemIndex.equipment
-			elseif string.match(stat.ObjectCategory, "Dye") or (stat.ObjectCategory == "" and stat.Name:find("Dye")) then
+			elseif string.match(stat.ObjectCategory, "Dye") or (stat.ObjectCategory == "" and stat.Name:upper():find("DYE")) then
 				indexShard = itemIndex.dyes
 			else
 				return

--- a/Armory/Mods/Armory/ScriptExtender/Lua/Client/Vanity/CharacterPanel/PickerBaseClass.lua
+++ b/Armory/Mods/Armory/ScriptExtender/Lua/Client/Vanity/CharacterPanel/PickerBaseClass.lua
@@ -86,7 +86,7 @@ function PickerBaseClass:InitializeSearchBank()
 
 			if (stat.ModifierList == "Weapon" or stat.ModifierList == "Armor") then
 				indexShard = itemIndex.equipment
-			elseif string.match(stat.ObjectCategory, "Dye") then
+			elseif string.match(stat.ObjectCategory, "Dye") or (stat.ObjectCategory == "" and stat.Name:find("Dye")) then
 				indexShard = itemIndex.dyes
 			else
 				return

--- a/Armory/Mods/Armory/ScriptExtender/Lua/Server/Vanity/Transmogger.lua
+++ b/Armory/Mods/Armory/ScriptExtender/Lua/Server/Vanity/Transmogger.lua
@@ -788,7 +788,7 @@ Ext.Osiris.RegisterListener("Equipped", 2, "after", function(item, character)
 	---@type EntityHandle
 	local itemEntity = Ext.Entity.Get(item)
 	if itemEntity.Vars.TheArmory_Vanity_Item_CurrentlyMogging then
-		itemEntity.Vars.TheArmory_Vanity_Item_CurrentlyMogging = nil
+		itemEntity.Vars.TheArmory_Vanity_Item_CurrentlyMogging = itemEntity.Vars.TheArmory_Vanity_PreviewItem ~= nil
 		Transmogger:ApplyDye(Ext.Entity.Get(character))
 	else
 		-- When swapping weapons between slots multiple equip/unequip events fire in rapid succession, and since we mog the whole character at once

--- a/Armory/Mods/Armory/ScriptExtender/Lua/Server/Vanity/Transmogger.lua
+++ b/Armory/Mods/Armory/ScriptExtender/Lua/Server/Vanity/Transmogger.lua
@@ -111,7 +111,7 @@ end
 Transmogger.saveLoadLock = false
 
 ---@param character EntityHandle
-function Transmogger:MogCharacter(character)
+function Transmogger:MogCharacter(character, skipJunk)
 	local characterPreset, charUserId = ServerPresetManager:GetCharacterPreset(character.Uuid.EntityUuid)
 
 	if not characterPreset then
@@ -197,7 +197,7 @@ function Transmogger:MogCharacter(character)
 		end
 
 		if not equippedItem then
-			if self.defaultPieces[actualSlot] and (vanity.settings and vanity.settings.general.fillEmptySlots) then
+			if self.defaultPieces[actualSlot] and (vanity.settings and vanity.settings.general.fillEmptySlots) and not skipJunk then
 				equippedItem = Osi.CreateAt(self.defaultPieces[actualSlot], 0, 0, 0, 0, 0, "")
 			else
 				goto continue
@@ -775,7 +775,7 @@ Ext.Osiris.RegisterListener("Unequipped", 2, "after", function(item, character)
 		local newItem = Transmogger:UnMogItem(item)
 		if newItem and not Ext.Entity.Get(newItem).Vars.TheArmory_Vanity_Item_CurrentlyMogging then
 			Ext.Timer.WaitFor(20, function()
-				Transmogger:MogCharacter(Ext.Entity.Get(character))
+				Transmogger:MogCharacter(Ext.Entity.Get(character), true)
 			end)
 		end
 	end)
@@ -788,8 +788,10 @@ Ext.Osiris.RegisterListener("Equipped", 2, "after", function(item, character)
 	---@type EntityHandle
 	local itemEntity = Ext.Entity.Get(item)
 	if itemEntity.Vars.TheArmory_Vanity_Item_CurrentlyMogging then
-		itemEntity.Vars.TheArmory_Vanity_Item_CurrentlyMogging = itemEntity.Vars.TheArmory_Vanity_PreviewItem ~= nil
-		Transmogger:ApplyDye(Ext.Entity.Get(character))
+		if not itemEntity.Vars.TheArmory_Vanity_PreviewItem then
+			itemEntity.Vars.TheArmory_Vanity_Item_CurrentlyMogging = nil
+			Transmogger:ApplyDye(Ext.Entity.Get(character))
+		end
 	else
 		-- When swapping weapons between slots multiple equip/unequip events fire in rapid succession, and since we mog the whole character at once
 		-- need to make sure we don't rapid fire a bunch of transmogs while timers are still processing
@@ -812,14 +814,14 @@ Ext.Osiris.RegisterListener("Equipped", 2, "after", function(item, character)
 						item,
 						character)
 
-					Transmogger:MogCharacter(Ext.Entity.Get(character))
+					Transmogger:MogCharacter(Ext.Entity.Get(character), true)
 				end)
 			else
 				Logger:BasicDebug("Item %s was equipped on %s, executing transmog",
 					item,
 					character)
 
-				Transmogger:MogCharacter(Ext.Entity.Get(character))
+				Transmogger:MogCharacter(Ext.Entity.Get(character), true)
 			end
 		end)
 	end


### PR DESCRIPTION
- Finds dyes that don't have the DyeCategory on the stat set
- Disables keyboard navigation for the Favorites icon in the dye picker, allowing up and down arrow keys + spacebar to be used to cycle through dyes
- Cleans up junk items from the dye preview properly, and make unmogging equipment a bit smoother
- Only generate junk items during normal transmogging on preset activation or level load, instead of all (un)equip events